### PR TITLE
Implement memoization to attributes

### DIFF
--- a/lib/norton/counter.rb
+++ b/lib/norton/counter.rb
@@ -15,75 +15,91 @@ module Norton
       #
       # @return [type] [description]
       def counter(name, options={}, &blk)
-        self.register_norton_value(name, :counter)
+        register_norton_value(name, :counter)
 
+        # Redis: GET
         define_method(name) do
-          Norton.redis.with do |conn|
-            conn.get(self.norton_value_key(name)).try(:to_i) || send("#{name}_default_value".to_sym)
+          instance_variable_get("@#{name}") || begin
+            value = Norton.redis.with do |conn|
+              conn.get(norton_value_key(name))
+            end || send("#{name}_default_value")
+            instance_variable_set("@#{name}", value.to_i)
+          end
+        end
+
+        # Redis: SET
+        define_method("#{name}=") do |value|
+          if Norton.redis.with { |conn| conn.set(norton_value_key(name), value) }
+            instance_variable_set("@#{name}", value.to_i)
           end
         end
 
         define_method("#{name}_default_value") do
           0
         end
-        send(:private, "#{name}_default_value".to_sym)
 
+        # Redis: INCR
         define_method("incr_#{name}") do
-          Norton.redis.with do |conn|
-            conn.incr(self.norton_value_key(name))
+          value = Norton.redis.with do |conn|
+            conn.incr(norton_value_key(name))
           end
+          instance_variable_set("@#{name}", value.to_i)
         end
 
+        # Redis: DECR
         define_method("decr_#{name}") do
-          Norton.redis.with do |conn|
-            conn.decr(self.norton_value_key(name))
+          value = Norton.redis.with do |conn|
+            conn.decr(norton_value_key(name))
           end
+          instance_variable_set("@#{name}", value.to_i)
         end
 
+        # Redis: INCRBY
         define_method("incr_#{name}_by") do |increment|
-          Norton.redis.with do |conn|
-            conn.incrby(self.norton_value_key(name), increment)
+          value = Norton.redis.with do |conn|
+            conn.incrby(norton_value_key(name), increment)
           end
+          instance_variable_set("@#{name}", value.to_i)
         end
 
+        # Redis: DECRBY
         define_method("decr_#{name}_by") do |decrement|
-          Norton.redis.with do |conn|
-            conn.decrby(self.norton_value_key(name), decrement)
+          value = Norton.redis.with do |conn|
+            conn.decrby(norton_value_key(name), decrement)
           end
+          instance_variable_set("@#{name}", value.to_i)
         end
 
-        define_method("#{name}=") do |v|
-          Norton.redis.with do |conn|
-            conn.set(self.norton_value_key(name), v)
-          end
-        end
-
+        # Redis: SET
         define_method("reset_#{name}") do
-          count = instance_eval(&blk)
+          value = instance_eval(&blk)
 
           Norton.redis.with do |conn|
-            conn.set(self.norton_value_key(name), count)
+            conn.set(norton_value_key(name), value)
           end
+          instance_variable_set("@#{name}", value)
         end
 
+        # Redis: DEL
         define_method("remove_#{name}") do
           Norton.redis.with do |conn|
-            conn.del(self.norton_value_key(name))
+            conn.del(norton_value_key(name))
           end
+          remove_instance_variable("@#{name}")
         end
         send(:after_destroy, "remove_#{name}".to_sym) if respond_to? :after_destroy
 
         # Add Increment callback
         unless options[:incr].nil?
           options[:incr].each do |callback|
-            self.send callback, proc{ instance_eval("incr_#{name}") }
+            send callback, proc{ instance_eval("incr_#{name}") }
           end
         end
 
         # Add Decrement callback
         unless options[:decr].nil?
           options[:decr].each do |callback|
-            self.send callback, proc{ instance_eval("decr_#{name}") }
+            send callback, proc{ instance_eval("decr_#{name}") }
           end
         end
       end

--- a/spec/norton/counter_spec.rb
+++ b/spec/norton/counter_spec.rb
@@ -1,10 +1,9 @@
-require 'spec_helper'
+require "spec_helper"
 
 class Dummy
   include Norton::Counter
 
   counter :candies_count, {} do
-    # puts 'hahaha'
     candies
   end
 
@@ -18,40 +17,127 @@ class Dummy
 end
 
 describe Norton::Counter do
-  describe "reset counter" do
-    it 'should set candies_count' do
-      dummy = Dummy.new
-      dummy.reset_candies_count
+  let(:dummy) { Dummy.new }
 
-      expect(dummy.candies_count).to eq(15)
+  it "responds to methods" do
+    expect(dummy.respond_to?(:candies_count)).to be(true)
+    expect(dummy.respond_to?(:candies_count=)).to be(true)
+    expect(dummy.respond_to?(:candies_count_default_value)).to be(true)
+    expect(dummy.respond_to?(:incr_candies_count)).to be(true)
+    expect(dummy.respond_to?(:decr_candies_count)).to be(true)
+    expect(dummy.respond_to?(:incr_candies_count_by)).to be(true)
+    expect(dummy.respond_to?(:decr_candies_count_by)).to be(true)
+    expect(dummy.respond_to?(:reset_candies_count)).to be(true)
+  end
+
+  describe "#candies_count" do
+    it "returns the value correctly" do
+      allow(dummy).to receive(:candies_count_default_value) { 123 }
+
+      expect(dummy.candies_count).to eq(123)
+      expect(dummy.instance_variable_get(:@candies_count)).to eq(123)
     end
   end
 
-  describe "assign value to counter" do
-    it 'should be able to assign a value to the counter' do
-      dummy = Dummy.new
-      dummy.candies_count = 200
+  describe "#candies_count=" do
+    it "assigns a value to the counter" do
+      dummy.candies_count = "200"
 
-      expect(dummy.candies_count).to eq(200)
+      value_in_redis = Norton.redis.with do |conn|
+        conn.get(dummy.norton_value_key(:candies_count))
+      end
+      expect(value_in_redis.to_i).to eq(200)
+      expect(dummy.instance_variable_get(:@candies_count)).to eq(200)
     end
   end
 
-  describe ".incr_value_by" do
-    it "should increase the value of the given amount" do
-      dummy = Dummy.new
+  describe "#candies_count_default_value" do
+    it "returns correct default value" do
+      expect(dummy.candies_count_default_value).to eq(0)
+    end
+  end
+
+  describe "#incr_candies_count" do
+    it "increases the value by one" do
+      dummy.incr_candies_count
+
+      value_in_redis = Norton.redis.with do |conn|
+        conn.get(dummy.norton_value_key(:candies_count))
+      end
+      expect(value_in_redis.to_i).to eq(1)
+      expect(dummy.instance_variable_get(:@candies_count)).to eq(1)
+    end
+  end
+
+  describe "#decr_candies_count" do
+    it "decreases the value by one" do
+      dummy.candies_count = 15
+      dummy.decr_candies_count
+
+      value_in_redis = Norton.redis.with do |conn|
+        conn.get(dummy.norton_value_key(:candies_count))
+      end
+      expect(value_in_redis.to_i).to eq(14)
+      expect(dummy.instance_variable_get(:@candies_count)).to eq(14)
+    end
+  end
+
+  describe "#incr_candies_count_by" do
+    it "increases the value of the given amount" do
       dummy.incr_candies_count_by(3)
 
-      expect(dummy.candies_count).to eq(3)
+      value_in_redis = Norton.redis.with do |conn|
+        conn.get(dummy.norton_value_key(:candies_count))
+      end
+      expect(value_in_redis.to_i).to eq(3)
+      expect(dummy.instance_variable_get(:@candies_count)).to eq(3)
     end
   end
 
-  describe ".decr_value_by" do
-    it "should decrease the value of the given amount" do
-      dummy = Dummy.new
+  describe "#decr_candies_count_by" do
+    it "decreases the value of the given amount" do
       dummy.candies_count = 15
       dummy.decr_candies_count_by(5)
 
-      expect(dummy.candies_count).to eq(10)
+      value_in_redis = Norton.redis.with do |conn|
+        conn.get(dummy.norton_value_key(:candies_count))
+      end
+      expect(value_in_redis.to_i).to eq(10)
+      expect(dummy.instance_variable_get(:@candies_count)).to eq(10)
+    end
+  end
+
+  describe "#reset_candies_count" do
+    it "resets candies_count" do
+      dummy.reset_candies_count
+
+      value_in_redis = Norton.redis.with do |conn|
+        conn.get(dummy.norton_value_key(:candies_count))
+      end
+      expect(value_in_redis.to_i).to eq(15)
+      expect(dummy.instance_variable_get(:@candies_count)).to eq(15)
+    end
+  end
+
+  describe "#remove_candies_count" do
+    it "deletes candies_count in redis" do
+      dummy.incr_candies_count_by(5)
+      expect(
+        Norton.redis.with { |conn| conn.exists(dummy.norton_value_key(:candies_count)) }
+      ).to be(true)
+
+      dummy.remove_candies_count
+      expect(
+        Norton.redis.with { |conn| conn.exists(dummy.norton_value_key(:candies_count)) }
+      ).to be(false)
+    end
+
+    it "removes the instance variable named by counter" do
+      dummy.incr_candies_count_by(5)
+      expect(dummy.instance_variable_defined?(:@candies_count)).to be(true)
+
+      dummy.remove_candies_count
+      expect(dummy.instance_variable_defined?(:@candies_count)).to be(false)
     end
   end
 end


### PR DESCRIPTION
- [x] 储存检索过的属性: `@attribute_name ||= read_attribute`
- [x] 重构 `model.norton_mget`
- [x] 重构 `Norton.mget`